### PR TITLE
fix(scrape): write example Amazon downloads to mounted ./downloads volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,6 @@ WORKDIR /home/pptruser/app
 # Create runtime directories
 RUN mkdir -p /home/pptruser/app/data \
     /home/pptruser/app/downloads \
-    /home/pptruser/app/documents \
     /home/pptruser/app/logs \
     /home/pptruser/app/browser-data \
     /home/pptruser/app/dist \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -58,7 +58,6 @@ WORKDIR /home/pptruser/app
 # Create directories for runtime data
 RUN mkdir -p /home/pptruser/app/data \
     /home/pptruser/app/downloads \
-    /home/pptruser/app/documents \
     /home/pptruser/app/logs \
     /home/pptruser/app/browser-data \
     /home/pptruser/app/dist \

--- a/apps/api/src/action-handler/actions/download.actions.ts
+++ b/apps/api/src/action-handler/actions/download.actions.ts
@@ -51,7 +51,7 @@ export class DownloadAction extends BaseAction<DownloadActionParams> {
         const segments = normalizedPath.split('/').filter((s) => s !== '');
 
         if (segments.length > 0) {
-          // Finde den Root-Teil (z.B. "./documents" oder "documents" oder "C:/documents")
+          // Finde den Root-Teil (z.B. "./downloads" oder "downloads" oder "C:/downloads")
           const rootParts: string[] = [];
           let restParts: string[] = [];
 

--- a/apps/api/src/action-handler/actions/file-exists.action.ts
+++ b/apps/api/src/action-handler/actions/file-exists.action.ts
@@ -17,11 +17,11 @@ export type FileExistsParams = {
  *
  * @example
  * // Prüfe ob eine spezifische Datei existiert
- * { "path": "./documents/amazon/2024/invoice-123.pdf" }
+ * { "path": "./downloads/amazon/2024/invoice-123.pdf" }
  *
  * @example
  * // Prüfe ob eine Datei mit Pattern existiert
- * { "path": "./documents/amazon/2024", "pattern": "amazon-invoice-123-*.pdf" }
+ * { "path": "./downloads/amazon/2024", "pattern": "amazon-invoice-123-*.pdf" }
  */
 @Action('fileExists', {
   displayName: 'File Exists',

--- a/apps/docs/src/content/docs/de/user-guide/actions/download.mdx
+++ b/apps/docs/src/content/docs/de/user-guide/actions/download.mdx
@@ -32,12 +32,15 @@ Die Download-Action organisiert Dateien automatisch in Unterordner basierend auf
 | `path` in Config | scrapeId | Tatsächlicher Speicherpfad |
 |-------------------|----------|---------------------------|
 | `./downloads` | `amazon` | `./downloads/amazon/` |
-| `./documents` | `amazon` | `./documents/amazon/` |
 | `./downloads/invoices` | `amazon` | `./downloads/amazon/invoices/` |
 | `./data/files` | `my-scrape` | `./data/my-scrape/files/` |
 
 <Aside type="caution">
 Verwende die scrapeId **nicht** nochmal in deinem `path` -- sie wird automatisch eingefügt! Wenn du `path` auf `./downloads/amazon` setzt und die scrapeId `amazon` ist, entsteht `./downloads/amazon/amazon/`.
+</Aside>
+
+<Aside type="caution">
+Im Standard-Docker-Setup ist nur `./downloads` als Volume gemountet. Wenn du in einen anderen Pfad speicherst (z.B. `./documents`), landen die Dateien innerhalb des Containers und gehen beim Neustart verloren. Verwende entweder `./downloads` oder ergänze ein passendes Volume-Mapping in deiner `docker-compose.yml`.
 </Aside>
 
 **Beispiel mit Docker-Volume-Mapping:**

--- a/apps/docs/src/content/docs/en/user-guide/actions/download.mdx
+++ b/apps/docs/src/content/docs/en/user-guide/actions/download.mdx
@@ -32,12 +32,15 @@ The download action automatically organizes files into subfolders based on the *
 | `path` in config | scrapeId | Actual save path |
 |-------------------|----------|------------------|
 | `./downloads` | `amazon` | `./downloads/amazon/` |
-| `./documents` | `amazon` | `./documents/amazon/` |
 | `./downloads/invoices` | `amazon` | `./downloads/amazon/invoices/` |
 | `./data/files` | `my-scrape` | `./data/my-scrape/files/` |
 
 <Aside type="caution">
 Don't include the scrapeId in your `path` -- it's added automatically! If you set `path` to `./downloads/amazon` and your scrapeId is `amazon`, you'll end up with `./downloads/amazon/amazon/`.
+</Aside>
+
+<Aside type="caution">
+The default Docker setup only mounts `./downloads` as a volume. If you save files to a different path (e.g. `./documents`), they'll be written inside the container and lost when it restarts. Either use `./downloads` or add a matching volume mount in your `docker-compose.yml`.
 </Aside>
 
 **Example with Docker volume mapping:**

--- a/config/sites/amazon.jsonc
+++ b/config/sites/amazon.jsonc
@@ -641,7 +641,7 @@
                                       "params": {
                                         "url": "{{currentData.invoiceLoop.value}}",
                                         "filename": "{{previousData.invoiceKey}}.pdf",
-                                        "path": "./documents"
+                                        "path": "./downloads"
                                       }
                                     },
                                     {


### PR DESCRIPTION
The bundled amazon.jsonc example used "./documents" as the download path,
but the documented Docker setup only mounts ./downloads. Files were
silently written to /home/pptruser/app/documents inside the container,
making them invisible on the host (closes #92).

- Switch amazon.jsonc download path to "./downloads"
- Stop pre-creating /home/pptruser/app/documents in the Dockerfiles so
  unmounted writes fail loudly instead of disappearing
- Sync docs and JSDoc examples to the ./downloads convention and warn
  about non-mounted custom paths