### PR TITLE
fix(ui): load debug data and artifacts for failed runs too

### DIFF
--- a/apps/ui/src/app/store/runs.store.spec.ts
+++ b/apps/ui/src/app/store/runs.store.spec.ts
@@ -1,0 +1,104 @@
+vi.mock('@angular/common/http', () => ({
+  HttpClient: class {},
+}));
+
+vi.mock('../services/scrape.service', () => ({
+  ScrapeService: class {},
+}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signal, computed } from '@angular/core';
+import { RunsStore } from './runs.store';
+import { ScrapeEvent } from '@scrape-dojo/shared';
+
+describe('RunsStore', () => {
+  let store: RunsStore;
+  let loadRunData: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = Object.create(RunsStore.prototype);
+
+    const _entities = signal<any[]>([
+      { id: 'run-1', scrapeId: 'scrape-1', status: 'running', steps: [] },
+    ]);
+    (store as any)._entities = _entities;
+    (store as any)._loading = signal(false);
+    (store as any)._error = signal<string | null>(null);
+    (store as any).entities = _entities.asReadonly();
+    (store as any).count = computed(() => _entities().length);
+    (store as any).isEmpty = computed(() => _entities().length === 0);
+
+    (store as any).config = {
+      storeName: 'Runs',
+      loadFn: vi.fn(),
+      eventTypes: [],
+    };
+    (store as any).logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    (store as any).scrapesStore = {
+      getById: () => () => undefined,
+      update: vi.fn(),
+    };
+
+    // updateWith aus der Basisklasse nachbilden — der Test zielt auf
+    // handleScrapeEnd, nicht auf den EntityStore.
+    (store as any).updateWith = (id: string, fn: (r: any) => any) => {
+      _entities.update((list) => list.map((e) => (e.id === id ? fn(e) : e)));
+    };
+
+    loadRunData = vi.fn();
+    (store as any).loadRunData = loadRunData;
+  });
+
+  function scrapeEnd(overrides: Partial<ScrapeEvent> = {}): ScrapeEvent {
+    return {
+      type: 'scrape-end',
+      runId: 'run-1',
+      scrapeId: 'scrape-1',
+      timestamp: Date.now(),
+      ...overrides,
+    } as ScrapeEvent;
+  }
+
+  describe('handleScrapeEnd', () => {
+    it('marks a run without error as success', () => {
+      store.handleEvent(scrapeEnd());
+
+      expect((store as any)._entities()[0].status).toBe('success');
+    });
+
+    it('marks a run with error as failed', () => {
+      store.handleEvent(scrapeEnd({ error: 'boom' } as Partial<ScrapeEvent>));
+
+      const run = (store as any)._entities()[0];
+      expect(run.status).toBe('failed');
+      expect(run.error).toBe('boom');
+    });
+
+    it('loads debug data and artifacts after a successful run', () => {
+      store.handleEvent(scrapeEnd());
+
+      expect(loadRunData).toHaveBeenCalledWith('run-1', 'scrape-1');
+    });
+
+    it('also loads debug data and artifacts after a FAILED run', () => {
+      // Regression: previously guarded by `status === 'success'`, so a failed
+      // run never got the data one actually needs to debug it.
+      store.handleEvent(scrapeEnd({ error: 'boom' } as Partial<ScrapeEvent>));
+
+      expect(loadRunData).toHaveBeenCalledWith('run-1', 'scrape-1');
+    });
+
+    it('does not load run data when the event carries no scrapeId', () => {
+      store.handleEvent(scrapeEnd({ scrapeId: undefined }));
+
+      expect(loadRunData).not.toHaveBeenCalled();
+    });
+
+    it('ignores events without a runId', () => {
+      store.handleEvent(scrapeEnd({ runId: undefined }));
+
+      expect(loadRunData).not.toHaveBeenCalled();
+      expect((store as any)._entities()[0].status).toBe('running');
+    });
+  });
+});

--- a/apps/ui/src/app/store/runs.store.ts
+++ b/apps/ui/src/app/store/runs.store.ts
@@ -263,8 +263,10 @@ export class RunsStore extends EntityStore<RunHistoryItem> {
       error: event.error,
     }));
 
-    // Nach erfolgreichem Abschluss: Lade Debug-Daten und Artifacts
-    if (status === 'success' && event.scrapeId) {
+    // Debug-Daten und Artifacts laden — auch bei fehlgeschlagenen Runs.
+    // Vorher lief das nur bei status === 'success', also ausgerechnet dann
+    // nicht, wenn man die Daten zur Fehlersuche am dringendsten braucht.
+    if (event.scrapeId) {
       this.loadRunData(event.runId, event.scrapeId);
     }
   }


### PR DESCRIPTION
## The problem

`RunsStore.handleScrapeEnd()` only fetches debug data and artifacts when a run finished successfully:

```ts
if (status === 'success' && event.scrapeId) {
  this.loadRunData(event.runId, event.scrapeId);
}
```

A **failed** run therefore never gets them — which is exactly the case where you want to look at them. Debugging a failure currently means reloading the page or querying the API by hand.

## The change

Drop the `status === 'success'` guard. That is the whole fix.

`loadRunData()` already handles its own errors and logs a warning if the endpoints do not answer, so a failed run that has no artifacts yet is harmless — it simply logs and moves on.

## Tests

Adds `runs.store.spec.ts`, which did not exist. Six cases around `handleScrapeEnd`:

- marks a run without error as `success`
- marks a run with error as `failed`, keeps the error text
- loads debug data and artifacts after a successful run
- **loads them after a failed run too** — the regression this PR fixes
- does not load when the event carries no `scrapeId`
- ignores events without a `runId`, leaving the run untouched

Full UI suite: **182 tests / 25 files, all passing.** `nx lint ui` clean.

## Context

Found while investigating #147 (run details staying empty during a run). That one is a separate, larger question and is deliberately **not** part of this PR — this is the small, independent piece that stands on its own.
