### PR TITLE
fix(ui): allow creating a secret once the list is no longer empty

### DIFF
--- a/apps/ui/src/app/components/secrets-manager/secrets-manager.html
+++ b/apps/ui/src/app/components/secrets-manager/secrets-manager.html
@@ -35,6 +35,11 @@
 
     <!-- Secrets List -->
     @if (!loading() && secrets().length > 0) {
+    <div class="flex justify-end mb-3">
+      <app-button variant="secondary" size="sm" (click)="openCreateModal()">
+        {{ 'secrets.create_button' | transloco }}
+      </app-button>
+    </div>
     <div class="border border-dojo-border rounded-md overflow-hidden">
       <table class="w-full">
         <thead class="bg-dojo-surface">


### PR DESCRIPTION
### Problem

The **create secret** button only exists inside the empty state:

```html
@if (!loading() && !error() && secrets().length === 0) {
  <app-button action variant="secondary" (click)="openCreateModal()">
    {{ 'secrets.create_button' | transloco }}
```

`openCreateModal()` is referenced exactly once in the template. As soon as one secret exists the block stops rendering, and the secrets manager offers **no other way to create another one**.

The remaining routes are not discoverable:

* the deep link `/(modal:secrets/create/<name>)`
* the run dialog, which links there — but only when a workflow already references a missing secret

So a user who has set up their first secret and later wants a second one finds a dialog that can only list and edit.

### Fix

Adds the same button above the list, so it is reachable in both states. Reuses the existing `secrets.create_button` key — no translation changes needed.

```html
<div class="flex justify-end mb-3">
  <app-button variant="secondary" size="sm" (click)="openCreateModal()">
    {{ 'secrets.create_button' | transloco }}
  </app-button>
</div>
```

`secondary` and `sm` are both valid members of `ButtonVariant` / `ButtonSize`.

### Verification

* `nx lint ui` — passes
* `nx build ui` — succeeds (the bundle-budget warning is pre-existing)
* Found on a running instance: four secrets existed and the dialog offered no way to add a fifth.